### PR TITLE
feat: add CashDrawer module

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { StyleSheet, View, Text, SectionList } from 'react-native';
 import {
   useBarcodeScanner,
+  useCashDrawer,
   useDeviceInformation,
   usePosPrinter,
 } from 'react-native-pos-tools';
@@ -26,6 +27,7 @@ export default function App() {
   const posPrinter = usePosPrinter();
   const deviceInformation = useDeviceInformation();
   const barcodeScanner = useBarcodeScanner();
+  const cashDrawer = useCashDrawer();
 
   return (
     <View style={styles.container}>
@@ -33,6 +35,7 @@ export default function App() {
         sections={[
           { title: 'POS Printer', data: [posPrinter] },
           { title: 'Barcode Scanner', data: [barcodeScanner] },
+          { title: 'Cash Drawer', data: [cashDrawer] },
           { title: 'Device Information', data: [deviceInformation] },
         ]}
         renderItem={({ item }) => <Section {...item} />}

--- a/src/NativeCashDrawer.ts
+++ b/src/NativeCashDrawer.ts
@@ -1,0 +1,21 @@
+import type { TurboModule } from 'react-native/Libraries/TurboModule/RCTExport';
+import { TurboModuleRegistry } from 'react-native';
+
+export interface CashDrawerSpec extends TurboModule {
+  /**
+   * Returns the first available cash drawer.
+   * @throws {Error} A device is not found.
+   * @see https://learn.microsoft.com/en-us/uwp/api/windows.devices.pointofservice.cashdrawer.getdefaultasync?view=winrt-22621#windows-devices-pointofservice-cashdrawer-getdefaultasync
+   */
+  getDefaultAsync(): Promise<ReactCashDrawer>;
+}
+
+export default TurboModuleRegistry.get<CashDrawerSpec>(
+  'CashDrawer'
+) as CashDrawerSpec | null;
+
+/** @link windows/ReactNativePosTools/NativeCashDrawer.cs */
+export interface ReactCashDrawer {
+  /** @see https://learn.microsoft.com/en-us/uwp/api/windows.devices.pointofservice.cashdrawer.deviceid?view=winrt-22621 */
+  DeviceId: string;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import NativeDeviceInformation from './NativeDeviceInformation';
 import NativeBarcodeScanner, {
   type ReactBarcodeScanner,
 } from './NativeBarcodeScanner';
+import NativeCashDrawer, { type ReactCashDrawer } from './NativeCashDrawer';
 
 class MethodUndefinedError extends Error {
   constructor({
@@ -138,6 +139,45 @@ export const useBarcodeScanner = () => {
       .getDefaultAsync()
       .then((scanner) => {
         setData(scanner);
+      })
+      .catch((err) => {
+        setError(err);
+      })
+      .finally(() => {
+        setLoading(false);
+      });
+  }, []);
+
+  return {
+    data,
+    error,
+    loading,
+  };
+};
+
+export const cashDrawer = {
+  getDefaultAsync: async () => {
+    if (NativeCashDrawer?.getDefaultAsync === undefined) {
+      throw new MethodUndefinedError({
+        moduleName: 'CashDrawer',
+        methodName: 'getDefaultAsync',
+      });
+    }
+
+    return NativeCashDrawer.getDefaultAsync();
+  },
+};
+
+export const useCashDrawer = () => {
+  const [data, setData] = React.useState<ReactCashDrawer | undefined>();
+  const [error, setError] = React.useState<Error | undefined>();
+  const [loading, setLoading] = React.useState<boolean>(true);
+
+  React.useEffect(() => {
+    cashDrawer
+      .getDefaultAsync()
+      .then((drawer) => {
+        setData(drawer);
       })
       .catch((err) => {
         setError(err);

--- a/windows/ReactNativePosTools/NativeCashDrawer.cs
+++ b/windows/ReactNativePosTools/NativeCashDrawer.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Microsoft.ReactNative.Managed;
+
+using Windows.Devices.PointOfService;
+
+namespace ReactNativePosTools
+{
+  // This is the structure that will be returned to the JavaScript side
+  // src/NativeCashDrawer.ts
+
+  struct ReactCashDrawer
+  {
+    public string DeviceId { get; set; }
+
+    public ReactCashDrawer(string deviceId)
+    {
+      DeviceId = deviceId;
+    }
+  };
+
+  [ReactModule("CashDrawer")]
+  internal class NativeCashDrawer
+  {
+
+    private CashDrawer drawer = null;
+
+    [ReactMethod("getDefaultAsync")]
+    public async void GetDefaultAsync(ReactPromise<ReactCashDrawer> result)
+    {
+      try
+      {
+        drawer = await CashDrawer.GetDefaultAsync();
+        if (drawer == null)
+        {
+          result.Reject(new ReactError { Message = "Cash Drawer was not found" });
+        }
+        else
+        {
+          result.Resolve(new ReactCashDrawer { DeviceId = drawer.DeviceId });
+        }
+      }
+      catch (Exception ex)
+      {
+        result.Reject(new ReactError { Message = ex.Message });
+      }
+    }
+  }
+}

--- a/windows/ReactNativePosTools/ReactNativePosTools.csproj
+++ b/windows/ReactNativePosTools/ReactNativePosTools.csproj
@@ -101,6 +101,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="NativeBarcodeScanner.cs" />
+    <Compile Include="NativeCashDrawer.cs" />
     <Compile Include="NativeDeviceInformation.cs" />
     <Compile Include="NativePosPrinter.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />


### PR DESCRIPTION
This PR adds support for the [CashDrawer](https://learn.microsoft.com/en-us/uwp/api/windows.devices.pointofservice.cashdrawer?view=winrt-22621) class in the [Windows.Devices.PointOfService](https://learn.microsoft.com/en-us/uwp/api/windows.devices.pointofservice?view=winrt-22621) namespace.

It also adds a hook and an example to the example app.